### PR TITLE
feat: Add support to django-ipware 3.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,12 @@ Change Log
 Unreleased
 ----------
 
+Added
+_______
+
+* Added support for django-ipware 3.0.0 .
+
+
 [0.3.1] - 2020-05-18
 --------------------
 

--- a/eox_audit_model/models.py
+++ b/eox_audit_model/models.py
@@ -18,7 +18,7 @@ from crum import get_current_request, get_current_user
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.db import models
-from ipware.ip import get_ip
+from ipware import ip
 
 from eox_audit_model.constants import Status
 from eox_audit_model.context_managers import capture_logs
@@ -51,7 +51,18 @@ def get_current_ip():
     """
     request = get_current_request()
 
-    return get_ip(request) if request else 'Missing ip.'
+    if not request:
+        return 'Missing ip.'
+
+    try:
+        # Works with django-ipware lower than 3.0.0
+        get_ip = getattr(ip, 'get_ip')
+
+        return get_ip(request)
+    except AttributeError:
+        get_client_ip = getattr(ip, 'get_client_ip')
+
+    return get_client_ip(request)[0]
 
 
 def get_current_performer():

--- a/eox_audit_model/tests/tests_models.py
+++ b/eox_audit_model/tests/tests_models.py
@@ -69,9 +69,9 @@ class TestGetCurrentSite(TestCase):
 class TestGetCurrentIp(TestCase):
     """Test cases for get_current_site."""
 
-    @patch('eox_audit_model.models.get_ip')
+    @patch('eox_audit_model.models.ip')
     @patch('eox_audit_model.models.get_current_request')
-    def test_valid_request(self, get_current_request_mock, get_ip_mock):
+    def test_valid_request(self, get_current_request_mock, ip_mock):
         """This method tests when the request is not None.
 
         Expected behavior:
@@ -81,18 +81,40 @@ class TestGetCurrentIp(TestCase):
         """
         request = Mock()
         expected_value = '192.163.45.67'
-        get_ip_mock.return_value = expected_value
+        ip_mock.get_ip.return_value = expected_value
         get_current_request_mock.return_value = request
 
         result = get_current_ip()
 
         self.assertEqual(expected_value, result)
         get_current_request_mock.assert_called_once()
-        get_ip_mock.assert_called_once_with(request)
+        ip_mock.get_ip.assert_called_once_with(request)
 
-    @patch('eox_audit_model.models.get_ip')
+    @patch('eox_audit_model.models.ip')
     @patch('eox_audit_model.models.get_current_request')
-    def test_invalid_request(self, get_current_request_mock, get_ip_mock):
+    def test_valid_request_with_get_client(self, get_current_request_mock, ip_mock):
+        """This method tests get_client_ip for django-ipware major or equals to 3.0.0
+
+        Expected behavior:
+            - Return expected value.
+            - get_current_request is called once.
+            - get_client_ip is called once.
+        """
+        request = Mock()
+        expected_value = '192.163.45.67'
+        ip_mock.get_ip.side_effect = AttributeError()
+        ip_mock.get_client_ip.return_value = (expected_value, )
+        get_current_request_mock.return_value = request
+
+        result = get_current_ip()
+
+        self.assertEqual(expected_value, result)
+        get_current_request_mock.assert_called_once()
+        ip_mock.get_client_ip.assert_called_once_with(request)
+
+    @patch('eox_audit_model.models.ip')
+    @patch('eox_audit_model.models.get_current_request')
+    def test_invalid_request(self, get_current_request_mock, ip_mock):
         """This method tests when the request is None.
 
         Expected behavior:
@@ -107,7 +129,7 @@ class TestGetCurrentIp(TestCase):
 
         self.assertEqual(expected_value, result)
         get_current_request_mock.assert_called_once()
-        get_ip_mock.assert_not_called()
+        ip_mock.get_ip.assert_not_called()
 
 
 class TestGetCurrentPerformer(TestCase):


### PR DESCRIPTION
## Description 

the method get_ip was change to get_client_ip hence this version supports both methods