### PR TITLE
feat: add wrapper method and option to record sensitive data

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,13 @@ Change Log
 Unreleased
 ----------
 
+Added
+-----
+
+* Display date in admin list view and use date format with ms
+* Include an API wrapper to be used in API views to record the request data.
+  Add an option to record sensitive data without the actual value.
+
 [0.4.0] - 2021-05-24
 --------------------
 

--- a/eox_audit_model/admin.py
+++ b/eox_audit_model/admin.py
@@ -65,6 +65,13 @@ class AuditAdmin(admin.ModelAdmin):
         list_filter: Define the admin filters.
     """
 
+    def timestamp_microseconds(self, obj):
+        """Format date with microseconds"""
+        return obj.audit_date_stamp.strftime("%Y-%m-%d %H:%M:%S.%f")
+
+    timestamp_microseconds.short_description = 'Audit date stamp'
+    timestamp_microseconds.admin_order_field = 'audit_date_stamp'
+
     inlines = (AuditNotesInline, AddAuditNotesInline)
     list_display = [
         'status',
@@ -72,6 +79,7 @@ class AuditAdmin(admin.ModelAdmin):
         'action',
         'performer',
         'site',
+        'timestamp_microseconds'
     ]
 
     search_fields = [
@@ -94,7 +102,7 @@ class AuditAdmin(admin.ModelAdmin):
         'input_parameters',
         'output_parameters',
         'traceback_log',
-        'audit_date_stamp',
+        'timestamp_microseconds',
         'ip',
     ]
 
@@ -108,7 +116,7 @@ class AuditAdmin(admin.ModelAdmin):
         'output_parameters',
         'captured_logs',
         'traceback_log',
-        'audit_date_stamp',
+        'timestamp_microseconds',
         'ip',
     ]
 

--- a/eox_audit_model/decorators.py
+++ b/eox_audit_model/decorators.py
@@ -37,3 +37,56 @@ def audit_method(action='Undefined action.'):
         return wrapper
 
     return decorator
+
+
+def rename_function(name=''):
+    """Change the __name__ atribute of a function to the given name parameter if any.
+    This allows to provide a more descriptive method name than `api_method`.
+    """
+    def decorator(func):
+        """Decorator function"""
+        if name:
+            func.__name__ = name
+        return func
+    return decorator
+
+
+def audit_drf_api(action='', data_filter=None, hidden_fields=None, method_name='api_method'):
+    """This decorator wraps the functionality of audit_method in order to
+    work with django API view methods,also this allows to filter the data that will be
+    stored in the data base.
+
+    Example
+
+    class YourAPIView(APIView):
+
+        @audit_api_wrapper(action='Get my items', data_filter=['username', 'location'])
+        def get(self, request, *args, **kwargs):
+            ...
+    """
+    def decorator(func):  # pylint: disable=missing-docstring
+        @wraps(func)
+        def wrapper(*args, **kwargs):  # pylint: disable=missing-docstring
+            request = args[1]
+            data = request.data if request.data else request.query_params
+
+            audit_data = {
+                key: value
+                for key, value in data.items()
+                if data_filter and key in data_filter
+            }
+            audit_data.update(
+                {key: '*****' for key in data if hidden_fields and key in hidden_fields}
+            )
+
+            @audit_method(action=action)
+            @rename_function(name=method_name)
+            def api_method(audit_data):  # pylint: disable=unused-argument
+                """This method is just a wrapper in order to capture the input data"""
+                return func(*args, **kwargs)
+
+            return api_method(audit_data)
+
+        return wrapper
+
+    return decorator


### PR DESCRIPTION
 # Description

* Add the `audit_api_wrapper` decorator (taken from eox-core) and include option to record sensitive data. This decorator wraps django API views and stores the data sent by the request. What to store is defined by the `data_filter` and `hidden_fields` (for sensitive data) parameters.
* Modify admin to include date in the list view and use a date format with ms

reference: eox-core code [audit_wrapper.py](https://github.com/eduNEXT/eox-core/blob/9b5c615ea70784711180daede759578b88cf8b63/eox_core/integrations/audit_wrapper.py) 