### PR TITLE
feat: Add option to save all request parameters and handle bulk requests in decorator

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,16 @@ Change Log
 Unreleased
 ----------
 
+[0.6.0] - 2021-08-18
+--------------------
+
+Added
+-----
+
+* Support for batch requests. Handle lists in request data.
+* Include new argument in decorator to show all the input parameters from the request.
+
+
 [0.5.1] - 2021-07-16
 --------------------
 


### PR DESCRIPTION
This PR changes the eox-audit-model decorator to accomplish two main things

1. If the decorator arg `save_all_parameters` is True, then all the input parameters are saved in the audit data. All the fields that are not in the filter_data list are shown as hidden fields to avoid leaking sensible information.
Audit register with `save_all_parameters` = False
![audit-save-all-false](https://user-images.githubusercontent.com/35777155/129886344-ff340056-efca-40e3-9770-c546c38d7191.png)
Audit register with `save_all_parameters` = True
![audit-save-all-true](https://user-images.githubusercontent.com/35777155/129886395-64fa5490-7430-441d-b54c-777e35acd72d.png)

2. The decorator now handles bulks operations (lists as input parameters)
An example for bulk enrollments
![audit-bulk-enrollment-data](https://user-images.githubusercontent.com/35777155/129886190-238cc606-37fb-44e2-b619-4a253164b0a3.png)


Additional information https://3.basecamp.com/3966315/buckets/8050706/todos/3992321197#__recording_3996855079
