### PR TITLE
fix: solve has_add_permission issue

### DIFF
--- a/eox_audit_model/admin.py
+++ b/eox_audit_model/admin.py
@@ -29,7 +29,7 @@ class AuditNotesInline(admin.StackedInline):
     readonly_fields = ['title', 'description']
     can_delete = False
 
-    def has_add_permission(self, request):  # pylint: disable=arguments-differ
+    def has_add_permission(self, request, obj=None):  # pylint: disable=arguments-differ
         """Adding registers is not allow."""
         return False
 


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

This PR solves the `has_add_permission() takes 2 positional arguments but 3 were given` error.

## How to test
Add this to strains/mango/strain.yml

```yml
VOLUME_OVERRIDES:
  # Another plugins ...
  # Public Plugins
      - DESTINATION: ../../src/edxapp/eox-audit-model
        LOCATION: /openedx/extra_deps/eox-audit-model
EXPORT_VOLUMES:
  # Another plugins ...
  # Public Plugins
    - CONTAINER: lms
      LOCATION: /openedx/extra_deps/eox-audit-model
      DESTINATION: src/edxapp/eox-audit-model
      UNSHALLOW: false
```

Init local and dev strain/mango

```bash
strain init strains/mango local -c
# Then run this
strain init strains/mango dev -c 
```

Now open a terminal in this location `stack-builder/strains/mango/src/edxapp/eox_audit_model`. Then change it to this branch `sebas/fixture-admin-permission`

```bash
git checkout sebas/fixture-admin-permission
```

To check the after and before, open the eox-audit-model admin file with your code editor, which is placed in `strains/mango/src/edxapp/eox_audit_model/admin.py` and on the line 32 change this:

```python
def has_add_permission(self, request, obj=None):  # pylint: disable=arguments-differ
```

To this:

```python
def has_add_permission(self, request):  # pylint: disable=arguments-differ
```

Then create a new audit-model and try to review it in the admin.
## Result
**After**
![Screenshot from 2022-05-11 11-07-49](https://user-images.githubusercontent.com/18581590/167896794-6fad01e0-1478-4e58-a64b-a88ca5a590d3.png)
**Before**
![Screenshot from 2022-05-11 11-09-41](https://user-images.githubusercontent.com/18581590/167896951-538e2a9b-0d24-4de3-9919-c3702765bb64.png)
