### PR TITLE
fix: fix workflow version error when upload pip image to pypi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@
 
 version: 2.1
 workflows:
-  version: 2.1
   test:
     jobs:
       - test:


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

This PR solves this error when an image is uploading to pypi:
```bash
Checking dist/eox_audit_model-0.7.1-py3-none-any.whl: FAILED
  `long_description` has syntax errors in markup and would not be rendered on PyPI.
    line 86: Severe: Title level inconsistent:

    Decorator
    =========
Checking dist/eox_audit_model-0.7.1.tar.gz: FAILED
  `long_description` has syntax errors in markup and would not be rendered on PyPI.
    line 86: Severe: Title level inconsistent:

    Decorator
    =========

Exited with code exit status 1

```
The error on CircleCI:
https://app.circleci.com/pipelines/github/eduNEXT/eox-audit-model/163/workflows/99aaf511-9c25-44e1-b5a8-c4a7b8b225cc/jobs/485

The discuss into CircleCI about how to solve this:
https://discuss.circleci.com/t/no-workflow-when-create-release-through-github/38822/2