### PR TITLE
feat: add absolute uri to djrf-api audit decorator

### DIFF
--- a/eox_audit_model/decorators.py
+++ b/eox_audit_model/decorators.py
@@ -96,11 +96,11 @@ def audit_drf_api(
 
             @audit_method(action=action)
             @rename_function(name=method_name)
-            def api_method(*input_parameters):  # pylint: disable=unused-argument
+            def api_method(*input_parameters, absolute_uri=""):  # pylint: disable=unused-argument
                 """This method is just a wrapper in order to capture the input data"""
                 return func(*args, **kwargs)
 
-            return api_method(*input_parameters)
+            return api_method(*input_parameters, absolute_uri=request.build_absolute_uri())
 
         return wrapper
 


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

Hi, I am adding some audits to my views for the plugin Nelp. So I am using djrf decorator thats is nice saving the data of the request. 

![image](https://github.com/eduNEXT/eox-audit-model/assets/51926076/495361b2-e687-4070-a449-1c664100711c)

But  I would like to add the  URL like eox-tagging do it with path. 
![image](https://github.com/eduNEXT/eox-audit-model/assets/51926076/8dcde71f-2c50-4add-9e7e-1ce783190ea2)

The djrf decorator only uses the data in the args but not kwargs.
I think that the url is useful to filter or now some extra data of the input.

## BEFORE
Only args are used.
![2023-06-02_16-43](https://github.com/eduNEXT/eox-audit-model/assets/51926076/4ca8655d-5953-4ae1-b1c9-a55c918d8c55)

## AFTER

![Peek 2023-06-02 16-28](https://github.com/eduNEXT/eox-audit-model/assets/51926076/0dc983d0-dd53-48b1-9df6-5f156e0c2f9e)

## Testing instructions

Clone this branch, add the decorator to a djrf method in a view, and then test the audit fields.

## Additional information



## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [x] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->